### PR TITLE
Add weigh scale functionalities.

### DIFF
--- a/hx711.py
+++ b/hx711.py
@@ -130,7 +130,7 @@ class HX711(object):
         self.pd_sck_pin.value(0)
         self.channel = self._channel
         
-    def set_scale(self, s)
+    def set_scale(self, s):
         """
         Used to calibrate the sensor for a specific weigh scale.
         """

--- a/hx711.py
+++ b/hx711.py
@@ -29,6 +29,8 @@ class HX711(object):
     MIN_VALUE = const(0x800000)
     READY_TIMEOUT_SEC = const(5)
     SLEEP_DELAY_USEC = const(80)
+    TARE = 0 
+    SCALE = 1 
 
     def __init__(self, d_out: int, pd_sck: int, channel: int = CHANNEL_A_128):
         self.d_out_pin = Pin(d_out, Pin.IN)
@@ -127,6 +129,27 @@ class HX711(object):
         """
         self.pd_sck_pin.value(0)
         self.channel = self._channel
+        
+    def set_scale(self, s)
+        """
+        Used to calibrate the sensor for a specific weigh scale.
+        """
+        SCALE = s
+        
+    def tare(self):
+        """
+        Measures the imput 10 times and sets a tare for the scale
+        """
+        sum = 0
+        for i in range(11):
+            sum += self.read()
+        TARE = sum // 10
+    
+    def read_w(self):
+        """
+        Return the value in the weigh scale and with tare applied
+        """
+        return (self.read() - TARE) * SCALE
 
     def read(self, raw=False):
         """


### PR DESCRIPTION
It includes 3 functions to use the hx711 as a weigh scale interface.

self.tare() --> Used to tare the scale and offset it to zero.
self.set_scale --> Used to set a custom multiplier to convert the data into mass values
self.read_w() --> Used to read the data with multiplier and tare applied for weigh scale applications

Calibration procedure:
You will need a known weigh to calibrate the scale. First, use self.tare() to compensate for the weigh of the mounting. Next, put the weigh in the scale and use self.read_w(). Now, divide the output by the weigh and apply it to the self.set_scale('your_number_here'). Remember that some boards don't support floating point numbers, prefer to input a integer number in this cases.
After this procedure, the result of self.read_w() will be a float( or integer, depending on set_scale you inputed) of the weigh in the same unit as your calibration weigh.